### PR TITLE
fix(decrypt): Don't modify the class

### DIFF
--- a/lib/active_admin_versioning/active_admin/views/pages/show.rb
+++ b/lib/active_admin_versioning/active_admin/views/pages/show.rb
@@ -64,15 +64,7 @@ module ActiveAdminVersioning
           end
 
           def decrypte_value(method, value)
-            klass = resource.class
-
-            return klass.send(decrypted_method(method), value) if klass.respond_to? decrypted_method(method)
-
-            klass.encrypt_and_blind_index(base_method(method) => { type: :string })
-
-            value = klass.send(decrypted_method(method), value)
-
-            klass.reset_column_information
+            return resource.class.send(decrypted_method(method), value) if klass.respond_to? decrypted_method(method)
 
             value
           end

--- a/lib/active_admin_versioning/version.rb
+++ b/lib/active_admin_versioning/version.rb
@@ -1,3 +1,3 @@
 module ActiveAdminVersioning
-  VERSION = "0.3.0".freeze
+  VERSION = "0.3.1".freeze
 end


### PR DESCRIPTION
A solution would be to change the metaclass:

column_name = base_method(method)
class << resource
  encrypt_and_blind_index( column_name => { type: :string })
end
value = resource.class.send(decrypted_method(method), value)

But it is probably not necessary to implement this for now